### PR TITLE
fix: wrong arweave source

### DIFF
--- a/schema/network/network.go
+++ b/schema/network/network.go
@@ -61,7 +61,7 @@ const (
 func (n Network) Protocol() Protocol {
 	switch n {
 	case Arweave:
-		return ActivityPubProtocol
+		return ArweaveProtocol
 	case Ethereum, Polygon, Optimism, Arbitrum, Base, Crossbell, Avalanche, VSL, SatoshiVM, BinanceSmartChain, Gnosis, Linea, XLayer:
 		return EthereumProtocol
 	case Farcaster:


### PR DESCRIPTION
## Summary

wrong arweave source

## Checklist

- [x] The commit message follows [Angular Contributing guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit);
- [x] This implementation is consistent with the latest version of the [RSS3 Protocol](https://github.com/RSS3-Network/Protocol).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No